### PR TITLE
Isolate code editor to prevent it from overlapping elements in preview

### DIFF
--- a/src/_helpers/createRootContainer.js
+++ b/src/_helpers/createRootContainer.js
@@ -25,6 +25,7 @@ export const createRootContainer = () => {
       font-size: var(--docoff-code-font-size);
       line-height: var(--docoff-code-line-height);
       color: lightblue;
+      isolation: isolate;
     }
 
     .docoff-Code__editor {


### PR DESCRIPTION
When there are large, viewport-sized elements in the preview, for example backdrops, code editor used to steal interactions due to higher z-index. This fix prevents the editor from overlapping any content on page.